### PR TITLE
Deal with the duplicate CompanyRegistrationNumber,

### DIFF
--- a/api/throwapi/src/main/java/sosteam/throwapi/domain/store/controller/StoreController.java
+++ b/api/throwapi/src/main/java/sosteam/throwapi/domain/store/controller/StoreController.java
@@ -41,22 +41,25 @@ public class StoreController {
         // Bizno RegistrationNumber Confirm API Error checking
         int resultCode = confirmCompanyRegistrationNumber(storeSaveRequest.getCompanyRegistrationNumber());
         log.debug("BIZNO API RESULT CODE ={}",resultCode);
-        if(resultCode == -1) {
+        if(resultCode == -10) {
             throw new NoSuchRegistrationNumberException();
         } else if(resultCode < 0){
             throw new BiznoAPIException(resultCode);
         }
 
-        log.debug("StoreSaveRequest = {}", storeSaveRequest);
+        // if CompanyRegistrationNumber Form is XXX-XX-XXXXX,
+        // remove '-'
         // Call save Service
         StoreSaveDto dto = new StoreSaveDto(
                 storeSaveRequest.getName(),
-                storeSaveRequest.getCompanyRegistrationNumber(),
+                storeSaveRequest.getCompanyRegistrationNumber().replaceAll("-",""),
                 storeSaveRequest.getLatitude(),
                 storeSaveRequest.getLongitude(),
                 storeSaveRequest.getZipCode(),
                 storeSaveRequest.getFullAddress()
         );
+        log.debug("StoreSaveRequest = {}", storeSaveRequest);
+
         storeCreateService.saveStore(dto);
     }
 
@@ -92,8 +95,9 @@ public class StoreController {
         BiznoApiResponse response = biznoAPI.confirmCompanyRegistrationNumber(number);
         int resultCode;
         // 해당 번호 존재 X
-        if(response == null || response.getTotalCount() == 0) resultCode = -1;
+        if(response == null || response.getTotalCount() == 0) resultCode = -10;
         // BIZNO API 호출 관련 오류
+        // -1 : 미등록 사용자 -> Wrong API-KEY
         // -2 : 파라메터 오류
         // -3 : 1일 100건 조회수 초과
         // 9 : 기타 오류


### PR DESCRIPTION
#22 
- 같은 번호이지만 다른 형식일 경우 중복처리가 안되는 문제
- "-"를 뺀 10자리 숫자 형식으로 통일
- 위는  Controller에서 입력 받았을 때의 로그
- 아래는 StoreCreateService에 들어갔을 때의 로그
- "-" 처리가 잘되는 것을 확인할 수 있다.
<img width="705" alt="스크린샷 2023-08-26 오후 5 11 05" src="https://github.com/S-OSTeam/Throw/assets/137032025/4aaaa5b1-4f81-435a-b675-d1e9abb64d22">

<img width="597" alt="스크린샷 2023-08-26 오후 5 11 23" src="https://github.com/S-OSTeam/Throw/assets/137032025/b1d28033-2366-4dd5-8abb-9897c95a19a7">


## BIZNO 관련 resultCode
- `resultCode = -1` 이 `미등록 사용자`다. 미등록 사용자가 등록되지 않은 사업자 번호를 뜻하는지 알았으나, 테스트를 해보니 API-KEY관련 오류였다. 즉 미등록 사용자는 해당 API를 사용하는 사람들이였다.
- 만약에 사업자 등록 번호가 국세청에 등록되지 않은 경우 : `resultCode -> -10`
- API-Key 관련 오류일 경우 : `resultCode -> -1`
